### PR TITLE
fix wood harvest spikes

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7531140'
+ValidationKey: '7697280'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7697280'
+ValidationKey: '7697660'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: |-
   mrdownscale: Downscale and harmonize land use data using high resolution
       reference data
 version: 0.38.0
-date-released: '2025-06-17'
+date-released: '2025-06-18'
 abstract: Downscale and harmonize land use data (e.g. MAgPIE) using high resolution
   reference data (e.g. LUH2v2h).
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   mrdownscale: Downscale and harmonize land use data using high resolution
       reference data
-version: 0.37.2
-date-released: '2025-06-06'
+version: 0.38.0
+date-released: '2025-06-17'
 abstract: Downscale and harmonize land use data (e.g. MAgPIE) using high resolution
   reference data (e.g. LUH2v2h).
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: mrdownscale
 Title: Downscale and harmonize land use data using high resolution
     reference data
-Version: 0.37.2
-Date: 2025-06-06
+Version: 0.38.0
+Date: 2025-06-17
 Authors@R: c(
     person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-6856-8239")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: mrdownscale
 Title: Downscale and harmonize land use data using high resolution
     reference data
 Version: 0.38.0
-Date: 2025-06-17
+Date: 2025-06-18
 Authors@R: c(
     person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-6856-8239")),

--- a/R/calcLandInput.R
+++ b/R/calcLandInput.R
@@ -45,6 +45,7 @@ calcLandInput <- function(input) {
     out <- add_columns(out, "biofuel_1st_gen", fill = 0)
 
     expectedCategories <- toolGetMapping("referenceMappings/magpie.csv", where = "mrdownscale")$data
+    primf <- "primforest"
   } else {
     stop("Unsupported input type \"", input, "\"")
   }
@@ -57,8 +58,8 @@ calcLandInput <- function(input) {
   toolExpectTrue(all(out >= 0), "All values are >= 0")
   outSum <- dimSums(out, dim = 3)
   toolExpectLessDiff(outSum, outSum[, 1, ], 10^-4, "Total area is constant over time")
-  toolExpectTrue(all(out[, -1, "primforest"] <= setYears(out[, -nyears(out), "primforest"], getYears(out[, -1, ]))),
-                 "primforest is never expanding", falseStatus = "warn")
+  toolExpectTrue(all(out[, -1, primf] <= setYears(out[, -nyears(out), primf], getYears(out[, -1, ]))),
+                 "primary forest is never expanding", falseStatus = "warn")
 
   return(list(x = out,
               isocountries = FALSE,

--- a/R/calcLandInput.R
+++ b/R/calcLandInput.R
@@ -44,6 +44,7 @@ calcLandInput <- function(input) {
         }
       }
     }
+    # TODO clean up here
 
     scalingFactors <- totalCrop / dimSums(crop, dim = 3)
     scalingFactors[is.na(scalingFactors)] <- 1

--- a/R/calcLandInputRecategorized.R
+++ b/R/calcLandInputRecategorized.R
@@ -48,7 +48,7 @@ calcLandInputRecategorized <- function(input, target) {
     # if totaln shrinks, shrink primn and secdn according to their proportions in the previous timestep
     # if totaln expands, expand only secdn, primn stays constant
     totaln <- dimSums(out[, , c("primn", "secdn")], 3)
-    out <- toolReplaceExpansion(out, "primn", "secdn", warnThreshold = 20)
+    out <- toolReplaceExpansion(out, "primn", "secdn", warnThreshold = 20) # TODO warnThreshold = 100
 
     toolExpectLessDiff(dimSums(out[, , c("primn", "secdn")], 3), totaln, 10^-5,
                        paste("No change in sum of primn and secdn after replacing",

--- a/R/calcLandInputRecategorized.R
+++ b/R/calcLandInputRecategorized.R
@@ -48,7 +48,7 @@ calcLandInputRecategorized <- function(input, target) {
     # if totaln shrinks, shrink primn and secdn according to their proportions in the previous timestep
     # if totaln expands, expand only secdn, primn stays constant
     totaln <- dimSums(out[, , c("primn", "secdn")], 3)
-    out <- toolReplaceExpansion(out, "primn", "secdn", warnThreshold = 20) # TODO warnThreshold = 100
+    out <- toolReplaceExpansion(out, "primn", "secdn", warnThreshold = 100)
 
     toolExpectLessDiff(dimSums(out[, , c("primn", "secdn")], 3), totaln, 10^-5,
                        paste("No change in sum of primn and secdn after replacing",

--- a/R/calcLandTargetExtrapolated.R
+++ b/R/calcLandTargetExtrapolated.R
@@ -3,14 +3,12 @@
 #' Aggregated low resolution target data is extrapolated to the given years
 #' using toolExtrapolate and normalized afterwards, so that the total sum over
 #' all land types is unchanged.
-#' To account for the relationship between wood
-#' harvest area and primary land (which is no longer primary once it has been
-#' harvested) wood harvest area is calculated here even though it is otherwise
-#' considered a nonland variable. The share of woody land that was
-#' harvested in the historical period is calculated and then multiplied
-#' by the maximum possible harvest in the extrapolation period. Primary land
-#' is then converted to secondary land so the total reduction equals the area
-#' that was harvested.
+#' To account for the relationship between wood harvest area and primary land
+#' (which is no longer primary once it has been harvested) wood harvest area
+#' is calculated here even though it is a nonland variable. The share of
+#' woody land that was harvested in the historical period is calculated and
+#' then multiplied by land (already extrapolated). Primary land is then
+#' converted to secondary land, so that total reduction equals harvested area.
 #'
 #' @param input character, name of the input data set
 #' @param target character, name of the target data set
@@ -114,6 +112,7 @@ calcLandTargetExtrapolated <- function(input, target, harmonizationPeriod) {
               woodHarvestArea = harvest))
 }
 
+# extra function for better cache utilization
 calcLandTargetExtrapolatedCore <- function(input, target, harmonizationPeriod) {
   xInput <- calcOutput("LandInputRecategorized", input = input, target = target, aggregate = FALSE)
   inputYears <- getYears(xInput, as.integer = TRUE)

--- a/R/calcLandTargetExtrapolated.R
+++ b/R/calcLandTargetExtrapolated.R
@@ -18,10 +18,10 @@
 #' supplementary = TRUE and target is luh2mod wood harvest area is also returned
 #' @author Pascal Sauer
 calcLandTargetExtrapolated <- function(input, target, harmonizationPeriod) {
-  hp1 <- harmonizationPeriod[[1]]
+  hp1 <- harmonizationPeriod[1]
   xInput <- calcOutput("LandInputRecategorized", input = input, target = target, aggregate = FALSE)
   inputYears <- getYears(xInput, as.integer = TRUE)
-  transitionYears <- inputYears[inputYears > harmonizationPeriod[1] & inputYears < harmonizationPeriod[2]]
+  transitionYears <- inputYears[inputYears > hp1 & inputYears < harmonizationPeriod[2]]
 
   xTarget <- calcOutput("LandTargetLowRes", input = input, target = target, aggregate = FALSE)
   histYears <- getYears(xTarget, as.integer = TRUE)
@@ -87,15 +87,7 @@ calcLandTargetExtrapolated <- function(input, target, harmonizationPeriod) {
     toolExpectLessDiff(harvest[, histYears, ], harvestHist, 0,
                        "In historical period, wood harvest area was not changed")
     toolExpectTrue(min(harvest) >= 0, "wood harvest area is >= 0")
-
-    histYears <- getYears(harvest, as.integer = TRUE)
-    histYears <- histYears[histYears < transitionYears[1]]
-    toolCheckWoodHarvestArea(harvest[, histYears, ], out[, histYears, ],
-                             "In historical period, ")
-
-    futureYears <- setdiff(getYears(harvest, as.integer = TRUE), histYears)
-    toolCheckWoodHarvestArea(harvest[, futureYears, ], out[, futureYears, ],
-                             "After historical period, ")
+    toolCheckWoodHarvestArea(harvest, out, hp1)
   }
 
   # consistency checks land

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -21,7 +21,13 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   geometry <- attr(xInput, "geometry")
   crs <- attr(xInput, "crs")
 
-  biohMap <- toolBiohMapping()
+  biohMap <- as.data.frame(rbind(c("primf_bioh", "primf"),
+                                 c("secyf_bioh", "secdf"),
+                                 c("secmf_bioh", "secdf"),
+                                 c("pltns_bioh", "pltns"),
+                                 c("primn_bioh", "primn"),
+                                 c("secnf_bioh", "secdn")))
+  colnames(biohMap) <- c("bioh", "land")
   kgCPerMhaInput <- xInput[, , biohMap$bioh] / magclass::setNames(xInput[, , woodHarvestAreaCategories()],
                                                                   sub("wood_harvest_area$", "bioh",
                                                                       woodHarvestAreaCategories()))

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -91,6 +91,9 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   toolExpectTrue(min(out) >= 0, "All values are >= 0")
   # SpatRaster can hold values up to ~10^40 before replacing with Inf, so check we are well below that
   toolExpectTrue(max(out) < 10^30, "All values are < 10^30")
+  toolExpectLessDiff(out[, getYears(out, as.integer = TRUE) <= harmonizationPeriod[1], ],
+                     xTarget[, getYears(xTarget, as.integer = TRUE) <= harmonizationPeriod[1], ],
+                     10^-4, "Returning reference data before harmonization period")
 
   return(list(x = out,
               isocountries = FALSE,

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -31,10 +31,8 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   kgCPerMhaInput <- xInput[, , biohMap$bioh] / magclass::setNames(xInput[, , woodHarvestAreaCategories()],
                                                                   sub("wood_harvest_area$", "bioh",
                                                                       woodHarvestAreaCategories()))
-  kgCPerMhaInput[is.nan(kgCPerMhaInput)] <- 0
-  # should we prevent bioh without harvest area before this point, so the following line is no longer necessary?
-  kgCPerMhaInput[is.infinite(kgCPerMhaInput)] <- max(kgCPerMhaInput[is.finite(kgCPerMhaInput)])
-  stopifnot(is.finite(kgCPerMhaInput), kgCPerMhaInput >= 0)
+  kgCPerMhaInput[is.nan(kgCPerMhaInput)] <- min(kgCPerMhaInput[!is.nan(kgCPerMhaInput)])
+  stopifnot(0 < kgCPerMhaInput, kgCPerMhaInput < Inf)
   getItems(kgCPerMhaInput, 3) <- sub("bioh$", "kgC_per_Mha", getItems(kgCPerMhaInput, 3))
 
   xTarget <- calcOutput("NonlandTargetExtrapolated", input = input, target = target,
@@ -43,10 +41,8 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   kgCPerMhaTarget <- xTarget[, , biohMap$bioh] / magclass::setNames(xTarget[, , woodHarvestAreaCategories()],
                                                                     sub("wood_harvest_area$", "bioh",
                                                                         woodHarvestAreaCategories()))
-  kgCPerMhaTarget[is.nan(kgCPerMhaTarget)] <- 0
-  # should we prevent bioh without harvest area before this point, so the following line is no longer necessary?
-  kgCPerMhaTarget[is.infinite(kgCPerMhaTarget)] <- max(kgCPerMhaTarget[is.finite(kgCPerMhaTarget)])
-  stopifnot(is.finite(kgCPerMhaTarget), kgCPerMhaTarget >= 0)
+  kgCPerMhaTarget[is.nan(kgCPerMhaTarget)] <- min(kgCPerMhaTarget[!is.nan(kgCPerMhaTarget)])
+  stopifnot(0 < kgCPerMhaTarget, kgCPerMhaTarget < Inf)
   getItems(kgCPerMhaTarget, 3) <- sub("bioh$", "kgC_per_Mha", getItems(kgCPerMhaTarget, 3))
 
   harmonizer <- toolGetHarmonizer(harmonization)
@@ -61,18 +57,16 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
 
   # adapt bioh to harmonized harvest area
   kgCPerMhaHarmonized <- out[, , getItems(kgCPerMhaTarget, 3)]
-  # should we prevent harvest area without bioh before this point, so the following line is no longer necessary?
-  kgCPerMhaHarmonized[kgCPerMhaHarmonized == 0] <- min(kgCPerMhaHarmonized[kgCPerMhaHarmonized > 0])
-  stopifnot(is.finite(kgCPerMhaHarmonized), kgCPerMhaHarmonized >= 0)
+  stopifnot(0 < kgCPerMhaHarmonized, kgCPerMhaHarmonized < Inf)
   biohCalculated <- kgCPerMhaHarmonized * magclass::setNames(harvestArea,
                                                              sub("wood_harvest_area$", "kgC_per_Mha",
                                                                  getItems(harvestArea, 3)))
   getItems(biohCalculated, 3) <- sub("kgC_per_Mha$", "bioh", getItems(biohCalculated, 3))
-  stopifnot(0 <= biohCalculated, is.finite(biohCalculated))
+  stopifnot(0 <= biohCalculated, biohCalculated < Inf)
 
   biohNormalization <- dimSums(out[, , biohMap$bioh], 3) / dimSums(biohCalculated, 3)
   biohNormalization[is.nan(biohNormalization)] <- 0
-  stopifnot(0 <= biohNormalization, is.finite(biohNormalization))
+  stopifnot(0 <= biohNormalization, biohNormalization < Inf)
 
   biohAdapted <- biohNormalization * biohCalculated
 

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -78,8 +78,6 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   out <- mbind(out, harvestArea)
   out <- out[, , getItems(kgCPerMhaTarget, 3), invert = TRUE]
 
-# TODO primf_bioh drops to 0 in 2025, why?
-
   attr(out, "geometry") <- geometry
   attr(out, "crs")      <- crs
 

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -41,7 +41,7 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   kgCPerMhaTarget <- xTarget[, , biohMap$bioh] / magclass::setNames(xTarget[, , woodHarvestAreaCategories()],
                                                                     sub("wood_harvest_area$", "bioh",
                                                                         woodHarvestAreaCategories()))
-  kgCPerMhaTarget[is.nan(kgCPerMhaTarget)] <- min(kgCPerMhaTarget[!is.nan(kgCPerMhaTarget)])
+  kgCPerMhaTarget[!is.finite(kgCPerMhaTarget)] <- min(kgCPerMhaTarget[is.finite(kgCPerMhaTarget)])
   stopifnot(0 < kgCPerMhaTarget, kgCPerMhaTarget < Inf)
   getItems(kgCPerMhaTarget, 3) <- sub("bioh$", "kgC_per_Mha", getItems(kgCPerMhaTarget, 3))
 

--- a/R/calcNonlandHarmonized.R
+++ b/R/calcNonlandHarmonized.R
@@ -78,6 +78,8 @@ calcNonlandHarmonized <- function(input, target, harmonizationPeriod, harmonizat
   out <- mbind(out, harvestArea)
   out <- out[, , getItems(kgCPerMhaTarget, 3), invert = TRUE]
 
+# TODO primf_bioh drops to 0 in 2025, why?
+
   attr(out, "geometry") <- geometry
   attr(out, "crs")      <- crs
 

--- a/R/calcNonlandHighRes.R
+++ b/R/calcNonlandHighRes.R
@@ -34,6 +34,7 @@ calcNonlandHighRes <- function(input, target, harmonizationPeriod, yearsSubset, 
 
   futureYears <- getYears(x, as.integer = TRUE)
   futureYears <- futureYears[futureYears > harmonizationPeriod[1]]
+  histYears <- setdiff(getYears(x, as.integer = TRUE), futureYears)
 
   resmap <- calcOutput("ResolutionMapping", input = input, target = target, aggregate = FALSE)
 
@@ -124,7 +125,8 @@ calcNonlandHighRes <- function(input, target, harmonizationPeriod, yearsSubset, 
                  "Nonland categories remain unchanged")
   toolExpectTrue(min(out) >= 0, "All values are >= 0")
 
-  toolCheckWoodHarvestArea(out[, getYears(landHighRes), whaCat], landHighRes)
+  toolCheckWoodHarvestArea(out[, histYears, whaCat], landHighRes[, histYears, ], "In historical period, ")
+  toolCheckWoodHarvestArea(out[, futureYears, whaCat], landHighRes[, futureYears, ], "After historical period, ")
 
   return(list(x = out,
               min = 0,

--- a/R/calcNonlandHighRes.R
+++ b/R/calcNonlandHighRes.R
@@ -34,7 +34,6 @@ calcNonlandHighRes <- function(input, target, harmonizationPeriod, yearsSubset, 
 
   futureYears <- getYears(x, as.integer = TRUE)
   futureYears <- futureYears[futureYears > harmonizationPeriod[1]]
-  histYears <- setdiff(getYears(x, as.integer = TRUE), futureYears)
 
   resmap <- calcOutput("ResolutionMapping", input = input, target = target, aggregate = FALSE)
 
@@ -125,8 +124,7 @@ calcNonlandHighRes <- function(input, target, harmonizationPeriod, yearsSubset, 
                  "Nonland categories remain unchanged")
   toolExpectTrue(min(out) >= 0, "All values are >= 0")
 
-  toolCheckWoodHarvestArea(out[, histYears, whaCat], landHighRes[, histYears, ], "In historical period, ")
-  toolCheckWoodHarvestArea(out[, futureYears, whaCat], landHighRes[, futureYears, ], "After historical period, ")
+  toolCheckWoodHarvestArea(out[, , whaCat], landHighRes, harmonizationPeriod[1])
 
   return(list(x = out,
               min = 0,

--- a/R/calcNonlandInputRecategorized.R
+++ b/R/calcNonlandInputRecategorized.R
@@ -2,6 +2,7 @@
 #'
 #' Harmonize categories by mapping nonland input data categories to the categories of the nonland target dataset.
 #' See \code{\link{calcLandInputRecategorized}} for an explanation of the mapping procedure.
+#' Report and discard wood harvest area if there is zero wood harvest (bioh) or vice versa.
 #'
 #' @param input name of the input dataset, currently only "magpie"
 #' @param target name of the target dataset, currently only "luh2"

--- a/R/calcNonlandTargetExtrapolated.R
+++ b/R/calcNonlandTargetExtrapolated.R
@@ -64,6 +64,9 @@ calcNonlandTargetExtrapolated <- function(input, target, harmonizationPeriod) {
                      dimSums(out[, , roundFuelWood], 3),
                      10^5, "Harvest weight types are consistent")
   toolExpectTrue(min(out) >= 0, "All values are >= 0")
+  toolExpectLessDiff(out[, getYears(out, as.integer = TRUE) <= harmonizationPeriod[1], ],
+                     xTarget[, getYears(xTarget, as.integer = TRUE) <= harmonizationPeriod[1], ],
+                     10^-4, "Returning reference data before harmonization period")
 
   return(list(x = out,
               isocountries = FALSE,

--- a/R/calcWoodHarvestAreaHarmonized.R
+++ b/R/calcWoodHarvestAreaHarmonized.R
@@ -117,8 +117,7 @@ calcWoodHarvestAreaHarmonized <- function(input, target, harmonizationPeriod, ha
   toolExpectTrue(min(out) >= 0, "All values are >= 0")
   toolExpectLessDiff(out[, histYears, ], xTarget[, histYears, ], 0,
                      "history is not changed by harmonization")
-  toolCheckWoodHarvestArea(out[, histYears, ], landHarmonized[, histYears, ], "In historical period, ")
-  toolCheckWoodHarvestArea(out[, futureYears, ], landHarmonized[, futureYears, ], "After historical period, ")
+  toolCheckWoodHarvestArea(out, landHarmonized, harmonizationPeriod[1])
 
   return(list(x = out,
               isocountries = FALSE,

--- a/R/fullSCENARIOMIP.R
+++ b/R/fullSCENARIOMIP.R
@@ -7,7 +7,7 @@ fullSCENARIOMIP <- function(rev = numeric_version("0"), ..., scenario = "",
 
   revision <- if (identical(rev, numeric_version("0"))) format(Sys.time(), "%Y-%m-%d") else rev
 
-  fileSuffix <- paste0("_input4MIPs_landState_ScenarioMIP_PIK-MAgPIE-",
+  fileSuffix <- paste0("_input4MIPs_landState_ScenarioMIP_",
                        scenario, if (scenario != "") "-",
                        revision, "_gn_", min(yearsSubset), "-", max(yearsSubset), ".nc")
 
@@ -20,7 +20,8 @@ fullSCENARIOMIP <- function(rev = numeric_version("0"), ..., scenario = "",
                        references = paste0("https://github.com/pik-piam/mrdownscale and ",
                                            "https://wcrp-cmip.org/mips/scenariomip/"),
                        targetMIP = "ScenarioMIP",
-                       ncTitle = "MAgPIE Land-Use Data Harmonized and Downscaled using LUH3 historic as reference",
+                       ncTitle = paste0("REMIND-MAgPIE Land-Use Data Harmonized ",
+                                        "and Downscaled using LUH3 historic as reference"),
                        referenceDataset = paste0("LUH3 historic from https://aims2.llnl.gov/search/input4mips/ ",
                                                  "(institution_id = 'UofMD' and mip_era = 'CMIP7')"),
                        furtherInfoUrl = "NA")

--- a/R/fullSCENARIOMIP.R
+++ b/R/fullSCENARIOMIP.R
@@ -1,7 +1,7 @@
 fullSCENARIOMIP <- function(rev = numeric_version("0"), ..., scenario = "",
-                            harmonizationPeriod = c(2020, 2050),
-                            yearsSubset = 2020:2100,
-                            harmonization = "fade", downscaling = "magpieClassic",
+                            harmonizationPeriod = c(2020, 2060),
+                            yearsSubset = 1995:2100,
+                            harmonization = "fadeForest", downscaling = "magpieClassic",
                             compression = 2, progress = TRUE) {
   stopifnot(...length() == 0)
 

--- a/R/setequalDims.R
+++ b/R/setequalDims.R
@@ -1,0 +1,5 @@
+setequalDims <- function(a, b) {
+  return(setequal(getItems(a, 1), getItems(b, 1)) &&
+           setequal(getItems(a, 2), getItems(b, 2)) &&
+           setequal(getItems(a, 3), getItems(b, 3)))
+}

--- a/R/toolCheckWoodHarvestArea.R
+++ b/R/toolCheckWoodHarvestArea.R
@@ -8,37 +8,56 @@
 #' paste0(c("primf", "secyf", "secmf", "pltns", "primn", "secnf"), "_wood_harvest_area")
 #' @param land magpie object with at least the following categories:
 #' c("primf", "secdf", "pltns", "primn", "secdn")
-#' @param notePrefix character to prepend to the check's message
+#' @param endOfHistory The last year considered part of the historical period,
+#' will check and report consistency separately for history and after
 #'
 #' @author Pascal Sauer
-toolCheckWoodHarvestArea <- function(harvest, land, notePrefix = "") {
-  stopifnot(setequal(getItems(harvest, 1), getItems(land, 1)))
+toolCheckWoodHarvestArea <- function(harvest, land, endOfHistory) {
+  stopifnot(identical(getItems(harvest, 1), getItems(land, 1)))
+  if (nyears(harvest) < 2) {
+    message("less than 2 years provided, not checking wood harvest area")
+    return()
+  }
   harvest <- toolAggregateWoodHarvest(harvest)
   stopifnot(getItems(harvest, 3) %in% getItems(land, 3),
             identical(getYears(harvest), getYears(land)))
-  years <- getYears(land, as.integer = TRUE)
 
   maxHarvestPerYear <- toolMaxHarvestPerYear(land, split = FALSE)
   excessHarvestPerYear <- harvest[, -1, ] - maxHarvestPerYear
   stopifnot(identical(getItems(excessHarvestPerYear, 2), getItems(maxHarvestPerYear, 2)))
 
-  msg <- paste0(" (max yearly excess harvest: ", signif(max(excessHarvestPerYear), 3), " Mha)")
-  toolExpectTrue(max(excessHarvestPerYear) <= 10^-10,
-                 paste0(notePrefix, "wood harvest area is smaller than land ",
-                        "of the corresponding type", if (max(excessHarvestPerYear) > 10^-10) msg),
-                 level = 1)
+  checkArea <- function(x, notePrefix) {
+    msg <- paste0(" (max yearly excess harvest: ", signif(max(x), 3), " Mha)")
+    toolExpectTrue(max(x) <= 10^-10,
+                   paste0(notePrefix, "wood harvest area is smaller than land ",
+                          "of the corresponding type", if (max(x) > 10^-10) msg),
+                   level = 2)
+  }
+  harvestYears <- getYears(excessHarvestPerYear, as.integer = TRUE)
+  checkArea(excessHarvestPerYear[, harvestYears[harvestYears <= endOfHistory], ],
+            paste0("In historical period (until ", endOfHistory, "), "))
+  checkArea(excessHarvestPerYear[, harvestYears[harvestYears > endOfHistory], ],
+            paste0("After historical period (after ", endOfHistory, "), "))
 
   prim <- c("primf", "primn")
-  timestepLength <- new.magpie(years = years[-1], fill = diff(years))
-  maxPrim <- setYears(land[, -nyears(land), prim], years[-1]) - timestepLength * harvest[, -1, prim]
+  landYears <- getYears(land, as.integer = TRUE)
+  timestepLength <- new.magpie(years = landYears[-1], fill = diff(landYears))
+  maxPrim <- setYears(land[, -nyears(land), prim], landYears[-1]) - timestepLength * harvest[, -1, prim]
   primExcess <- land[, -1, prim] - maxPrim
 
-  msg <- paste0(" (", signif(max(primExcess), 3), "Mha more primf/primn than possible)")
-  toolExpectTrue(max(primExcess) <= 10^-10,
-                 paste0(notePrefix, "primf and primn are shrinking by at least ",
-                        "their respective wood harvest area",
-                        if (max(primExcess) > 10^-10) msg),
-                 level = 1)
+  checkPrim <- function(x, notePrefix) {
+    msg <- paste0(" (", signif(max(x), 3), "Mha more primf/primn than possible)")
+    toolExpectTrue(max(x) <= 10^-10,
+                   paste0(notePrefix, "primf and primn are shrinking by at least ",
+                          "their respective wood harvest area",
+                          if (max(x) > 10^-10) msg),
+                   level = 1)
+  }
+  primYears <- getYears(primExcess, as.integer = TRUE)
+  checkPrim(primExcess[, primYears[primYears <= endOfHistory], ],
+            paste0("In historical period (until ", endOfHistory, "), "))
+  checkPrim(primExcess[, primYears[primYears > endOfHistory], ],
+            paste0("After historical period (after ", endOfHistory, "), "))
 }
 
 toolWoodHarvestMapping <- function() {

--- a/R/toolCheckWoodHarvestArea.R
+++ b/R/toolCheckWoodHarvestArea.R
@@ -52,17 +52,6 @@ toolWoodHarvestMapping <- function() {
   return(map)
 }
 
-toolBiohMapping <- function() {
-  map <- as.data.frame(rbind(c("primf_bioh", "primf"),
-                             c("secyf_bioh", "secdf"),
-                             c("secmf_bioh", "secdf"),
-                             c("pltns_bioh", "pltns"),
-                             c("primn_bioh", "primn"),
-                             c("secnf_bioh", "secdn")))
-  colnames(map) <- c("bioh", "land")
-  return(map)
-}
-
 toolAggregateWoodHarvest <- function(woodHarvest) {
   map <- toolWoodHarvestMapping()
 

--- a/R/toolHarmonizeFadeForest.R
+++ b/R/toolHarmonizeFadeForest.R
@@ -7,19 +7,31 @@
 #' @inherit toolHarmonizeFade return
 #' @author Pascal Sauer
 toolHarmonizeFadeForest <- function(xInput, xTarget, harmonizationPeriod) {
+  hp1 <- harmonizationPeriod[1]
+
   x <- toolHarmonizeFade(xInput, xTarget, harmonizationPeriod, level = 4)
   years <- getYears(x, as.integer = TRUE)
   psf <- c("primf", "secdf")
   if (!all(psf %in% getItems(x, 3))) {
     return(x)
   }
-  hp1 <- harmonizationPeriod[1]
   forest <- dimSums(x[, years >= hp1, psf], 3)
+
+
+  a <- xTarget[, getYears(xTarget, TRUE) <= hp1, "primf"]
+  di <- -a[, -1, ] + setYears(a[, -nyears(a), ],
+                              getYears(a[, -1, ]))
+  meanPrimfDecline <- magpply(di, mean, DIM = 2)
+  b <- xTarget[, hp1, "primf"]
+  for (year in years[years > hp1]) {
+    b <- mbind(b, setYears(b[, nyears(b), ] - meanPrimfDecline, year))
+  }
+  b[b < 0] <- 0
 
   primf <- xTarget[, hp1, "primf"]
   for (year in years[years > hp1]) {
-    previousYear <- primf[, nyears(primf), ]
-    p <- mpmin(previousYear, forest[, year, ])
+    p <- mpmin(b[, year, ], forest[, year, ])
+    p <- mpmin(p, primf[, nyears(primf), ])
     p <- setYears(p, year)
     primf <- mbind(primf, p)
   }

--- a/R/toolMaxHarvestPerYear.R
+++ b/R/toolMaxHarvestPerYear.R
@@ -1,13 +1,16 @@
 #' toolMaxHarvestPerYear
 #'
-#' Calculate the maximum possible harvest area per year
-#' (dividing by timestep length for primary land, because it is converted to
-#' secondary land after harvest) based on the given land data.
+#' Calculate the maximum possible harvest area per year based on the
+#' given land data.
 #'
 #' @param land magpie object with at least the following categories:
 #' c("primf", "secdf", "pltns", "primn", "secdn")
 #' @param split if TRUE: split secdf to secyf and secdmf,
 #' rename secdf to secnf, and append "_wood_harvest_area" to names
+#' @param timestepAdjust if TRUE: divide values for primary land by timestep
+#' length. This makes sense, because once primary land has been harvested,
+#' it is converted to secondary land and thus cannot be harvested again.
+#' Might introduce unintended spikes when timestep length changes.
 #' @return magpie object with the maximum possible yearly wood harvest area
 #'
 #' @author Pascal Sauer

--- a/R/toolMaxHarvestPerYear.R
+++ b/R/toolMaxHarvestPerYear.R
@@ -30,7 +30,5 @@ toolMaxHarvestPerYear <- function(land, split = TRUE) {
 
   # cannot harvest full primf each year as it is converted to secdf after harvest
   maxHarvest[, , prim] <- maxHarvest[, , prim] / timestepLength
-# TODO always return variable names with _wood_harvest_area
-# TODO new assumption: can harvest secondary land each year (5 times for 5 year timestep), where to adapt code?
   return(maxHarvest)
 }

--- a/R/toolMaxHarvestPerYear.R
+++ b/R/toolMaxHarvestPerYear.R
@@ -11,11 +11,7 @@
 #' @return magpie object with the maximum possible yearly wood harvest area
 #'
 #' @author Pascal Sauer
-toolMaxHarvestPerYear <- function(land, split = TRUE) {
-  timestepLength <- new.magpie(years = getYears(land)[-1],
-                               fill = diff(getYears(land, as.integer = TRUE)))
-  stopifnot(timestepLength > 0)
-
+toolMaxHarvestPerYear <- function(land, split = TRUE, timestepAdjust = TRUE) {
   land <- land[, , c("primf", "secdf", "pltns", "primn", "secdn")]
   prim <- c("primf", "primn")
   if (split) {
@@ -28,7 +24,12 @@ toolMaxHarvestPerYear <- function(land, split = TRUE) {
   }
   maxHarvest <- setYears(land[, -nyears(land), ], getYears(land)[-1])
 
-  # cannot harvest full primf each year as it is converted to secdf after harvest
-  maxHarvest[, , prim] <- maxHarvest[, , prim] / timestepLength
+  if (timestepAdjust) {
+    timestepLength <- new.magpie(years = getYears(land)[-1],
+                                 fill = diff(getYears(land, as.integer = TRUE)))
+    stopifnot(timestepLength > 0)
+    # cannot harvest full primf each year as it is converted to secdf after harvest
+    maxHarvest[, , prim] <- maxHarvest[, , prim] / timestepLength
+  }
   return(maxHarvest)
 }

--- a/R/toolMaxHarvestPerYear.R
+++ b/R/toolMaxHarvestPerYear.R
@@ -1,11 +1,11 @@
 #' toolMaxHarvestPerYear
 #'
 #' Calculate the maximum possible harvest area per year
-#' (dividing by timestep length) based on the given land data.
+#' (dividing by timestep length for primary land, because it is converted to
+#' secondary land after harvest) based on the given land data.
 #'
 #' @param land magpie object with at least the following categories:
-#' c("primf", "secdf", "pltns_added_treecover",
-#'   "pltns_excl_added_treecover", "primn", "secdn")
+#' c("primf", "secdf", "pltns", "primn", "secdn")
 #' @param split if TRUE: split secdf to secyf and secdmf,
 #' rename secdf to secnf, and append "_wood_harvest_area" to names
 #' @return magpie object with the maximum possible yearly wood harvest area
@@ -17,14 +17,20 @@ toolMaxHarvestPerYear <- function(land, split = TRUE) {
   stopifnot(timestepLength > 0)
 
   land <- land[, , c("primf", "secdf", "pltns", "primn", "secdn")]
+  prim <- c("primf", "primn")
   if (split) {
     getItems(land, 3) <- sub("secdf", "secyf", getItems(land, 3))
     getItems(land, 3) <- sub("secdn", "secnf", getItems(land, 3))
     getItems(land, 3) <- paste0(getItems(land, 3), "_wood_harvest_area")
     land <- add_columns(land, "secmf_wood_harvest_area")
     land[, , "secmf_wood_harvest_area"] <- land[, , "secyf_wood_harvest_area"]
+    prim <- c("primf_wood_harvest_area", "primn_wood_harvest_area")
   }
   maxHarvest <- setYears(land[, -nyears(land), ], getYears(land)[-1])
-  maxHarvestPerYear <- maxHarvest / timestepLength
-  return(maxHarvestPerYear)
+
+  # cannot harvest full primf each year as it is converted to secdf after harvest
+  maxHarvest[, , prim] <- maxHarvest[, , prim] / timestepLength
+# TODO always return variable names with _wood_harvest_area
+# TODO new assumption: can harvest secondary land each year (5 times for 5 year timestep), where to adapt code?
+  return(maxHarvest)
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Downscale and harmonize land use data using high resolution
     reference data
 
-R package **mrdownscale**, version **0.37.2**
+R package **mrdownscale**, version **0.38.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrdownscale)](https://cran.r-project.org/package=mrdownscale) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11244475.svg)](https://doi.org/10.5281/zenodo.11244475) [![R build status](https://github.com/pik-piam/mrdownscale/workflows/check/badge.svg)](https://github.com/pik-piam/mrdownscale/actions) [![codecov](https://codecov.io/gh/pik-piam/mrdownscale/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrdownscale) [![r-universe](https://pik-piam.r-universe.dev/badges/mrdownscale)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Pascal Sauer <pascal.sauer@pik-po
 
 To cite package **mrdownscale** in publications use:
 
-Sauer P, Dietrich J (2025). "mrdownscale: Downscale and harmonize land use data using high resolution reference data." doi:10.5281/zenodo.11244475 <https://doi.org/10.5281/zenodo.11244475>, Version: 0.37.2, <https://github.com/pik-piam/mrdownscale>.
+Sauer P, Dietrich J (2025). "mrdownscale: Downscale and harmonize land use data using high resolution reference data." doi:10.5281/zenodo.11244475 <https://doi.org/10.5281/zenodo.11244475>, Version: 0.38.0, <https://github.com/pik-piam/mrdownscale>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,9 +58,9 @@ A BibTeX entry for LaTeX users is
     reference data},
   author = {Pascal Sauer and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.11244475},
-  date = {2025-06-06},
+  date = {2025-06-17},
   year = {2025},
   url = {https://github.com/pik-piam/mrdownscale},
-  note = {Version: 0.37.2},
+  note = {Version: 0.38.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
     reference data},
   author = {Pascal Sauer and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.11244475},
-  date = {2025-06-17},
+  date = {2025-06-18},
   year = {2025},
   url = {https://github.com/pik-piam/mrdownscale},
   note = {Version: 0.38.0},

--- a/man/calcLandTargetExtrapolated.Rd
+++ b/man/calcLandTargetExtrapolated.Rd
@@ -22,14 +22,12 @@ supplementary = TRUE and target is luh2mod wood harvest area is also returned
 Aggregated low resolution target data is extrapolated to the given years
 using toolExtrapolate and normalized afterwards, so that the total sum over
 all land types is unchanged.
-To account for the relationship between wood
-harvest area and primary land (which is no longer primary once it has been
-harvested) wood harvest area is calculated here even though it is otherwise
-considered a nonland variable. The share of woody land that was
-harvested in the historical period is calculated and then multiplied
-by the maximum possible harvest in the extrapolation period. Primary land
-is then converted to secondary land so the total reduction equals the area
-that was harvested.
+To account for the relationship between wood harvest area and primary land
+(which is no longer primary once it has been harvested) wood harvest area
+is calculated here even though it is a nonland variable. The share of
+woody land that was harvested in the historical period is calculated and
+then multiplied by land (already extrapolated). Primary land is then
+converted to secondary land, so that total reduction equals harvested area.
 }
 \author{
 Pascal Sauer

--- a/man/calcNonlandInputRecategorized.Rd
+++ b/man/calcNonlandInputRecategorized.Rd
@@ -28,6 +28,7 @@ nonland data with target categories
 \description{
 Harmonize categories by mapping nonland input data categories to the categories of the nonland target dataset.
 See \code{\link{calcLandInputRecategorized}} for an explanation of the mapping procedure.
+Report and discard wood harvest area if there is zero wood harvest (bioh) or vice versa.
 }
 \author{
 Pascal Sauer

--- a/man/toolCheckWoodHarvestArea.Rd
+++ b/man/toolCheckWoodHarvestArea.Rd
@@ -4,7 +4,7 @@
 \alias{toolCheckWoodHarvestArea}
 \title{toolCheckWoodHarvestArea}
 \usage{
-toolCheckWoodHarvestArea(harvest, land, notePrefix = "")
+toolCheckWoodHarvestArea(harvest, land, endOfHistory)
 }
 \arguments{
 \item{harvest}{magpie object with exactly the following categories:
@@ -13,7 +13,8 @@ paste0(c("primf", "secyf", "secmf", "pltns", "primn", "secnf"), "_wood_harvest_a
 \item{land}{magpie object with at least the following categories:
 c("primf", "secdf", "pltns", "primn", "secdn")}
 
-\item{notePrefix}{character to prepend to the check's message}
+\item{endOfHistory}{The last year considered part of the historical period,
+will check and report consistency separately for history and after}
 }
 \description{
 Check wood harvest area is not exceeding land area of the corresponding

--- a/man/toolHarmonizeFadeForest.Rd
+++ b/man/toolHarmonizeFadeForest.Rd
@@ -22,7 +22,8 @@ harmonization period and a smooth transition in between.
 }
 \description{
 Harmonize using \code{\link{toolHarmonizeFade}}, then sum up primf + secdf,
-then disaggregate again in a way that minimizes primf to secdf conversion.
+then disaggregate again in a way that minimizes primf to secdf conversion,
+without exceeding linear extrapolation of primf.
 }
 \author{
 Pascal Sauer

--- a/man/toolMaxHarvestPerYear.Rd
+++ b/man/toolMaxHarvestPerYear.Rd
@@ -4,22 +4,26 @@
 \alias{toolMaxHarvestPerYear}
 \title{toolMaxHarvestPerYear}
 \usage{
-toolMaxHarvestPerYear(land, split = TRUE)
+toolMaxHarvestPerYear(land, split = TRUE, timestepAdjust = TRUE)
 }
 \arguments{
 \item{land}{magpie object with at least the following categories:
-c("primf", "secdf", "pltns_added_treecover",
-  "pltns_excl_added_treecover", "primn", "secdn")}
+c("primf", "secdf", "pltns", "primn", "secdn")}
 
 \item{split}{if TRUE: split secdf to secyf and secdmf,
 rename secdf to secnf, and append "_wood_harvest_area" to names}
+
+\item{timestepAdjust}{if TRUE: divide values for primary land by timestep
+length. This makes sense, because once primary land has been harvested,
+it is converted to secondary land and thus cannot be harvested again.
+Might introduce unintended spikes when timestep length changes.}
 }
 \value{
 magpie object with the maximum possible yearly wood harvest area
 }
 \description{
-Calculate the maximum possible harvest area per year
-(dividing by timestep length) based on the given land data.
+Calculate the maximum possible harvest area per year based on the
+given land data.
 }
 \author{
 Pascal Sauer


### PR DESCRIPTION
- report and then discard wood harvest without wood harvest area or vice versa
- harmonization: primf now declines at least as fast as in historical period
- wood harvest area is now extrapolated by multiplying extrapolated land with the share "wood harvest area divided by land", before it was "divided by max possible harvest" which is timestep length dependent for primary land and thus introduce spikes when timestep length changed

the first plot is before/without this PR, the second with this PR
land:
![image](https://github.com/user-attachments/assets/cddbb085-4de5-4a8e-90a2-459c43efd9d2)
![image](https://github.com/user-attachments/assets/84183201-fddb-462e-87f7-9abbebbc3073)

wood harvest (bioh):
![image](https://github.com/user-attachments/assets/e2217e4e-fcce-42a1-9d3d-53431b2f5180)
![image](https://github.com/user-attachments/assets/992f4ab6-a49d-41b6-a0cc-07f029ca578b)

wood harvest area:
![image](https://github.com/user-attachments/assets/15b081c3-a4a1-465f-b1a8-c579c1487c97)
![image](https://github.com/user-attachments/assets/ca54b5c1-1b0b-45cc-9a3f-476ae65cbadc)
